### PR TITLE
Don't advance rng for `Deterministic`

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -3,7 +3,6 @@
 end
 
 function Distributions.rand(rng::AbstractRNG, d::Deterministic)
-    rand(rng)
     return d.val
 end
 Distributions.logpdf(d::Deterministic, x::T) where T<:Real = zero(x)


### PR DESCRIPTION
When considering for instance
```julia
julia> sys = System(ProportionalController([-1; 0]),
                    InvertedPendulum(),
                    AdditiveNoiseSensor(MvNormal(Σₒ)));

julia> Random.seed!(1);

julia> τ1 = rollout(sys; d=5);

julia> Random.seed!(1);

julia> τ2 = rollout(sys, NominalTrajectoryDistribution(sys, 5));
```
It turns out that the two trajectories diverge. This is because of the
way they are sampled:
```julia
o = sys.sensor(s)  # calls sensor(s) which internally does rand(Do(sensor, s))
a = sys.agent(o)   # calls agent(o) - no sampling
s′ = sys.env(s, a) # calls env(s, a) which internally samples

xo = rand(D.Do(s))      # explicitly samples
o = sys.sensor(s, xo)   # uses the sample
xa = rand(D.Da(o))      # explicitly samples
a = sys.agent(o, xa)    # uses the sample
xs = rand(D.Ds(s, a))   # explicitly samples
s′ = sys.env(s, a, xs)  # uses the sample
```

Since `Da` etc return deterministic values, the latter keeps advancing
the RNG, whereas the prior doesn't interface with the rng at all.

This commit will make both approaches consistent with each other.